### PR TITLE
New components

### DIFF
--- a/src/main/java/org/vaadin/firitin/components/VDiv.java
+++ b/src/main/java/org/vaadin/firitin/components/VDiv.java
@@ -1,27 +1,14 @@
 package org.vaadin.firitin.components;
 
-import com.vaadin.flow.component.Text;
-import org.vaadin.firitin.fluency.ui.FluentClickNotifier;
-import org.vaadin.firitin.fluency.ui.FluentComponent;
-import org.vaadin.firitin.fluency.ui.FluentHasComponents;
-import org.vaadin.firitin.fluency.ui.FluentHasSize;
-import org.vaadin.firitin.fluency.ui.FluentHasStyle;
-import org.vaadin.firitin.fluency.ui.FluentThemableLayout;
-
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HtmlContainer;
-import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
 
-@Tag(Tag.DIV)
-public class VDiv extends HtmlContainer implements FluentComponent<VDiv>, FluentClickNotifier<VDiv, VDiv>,
-        FluentHasComponents<VDiv>, FluentHasStyle<VDiv>, FluentThemableLayout<VDiv>, FluentHasSize<VDiv> {
+public class VDiv extends Div implements FluentHtmlContainer<VDiv>, FluentClickNotifierWithoutTypedSource<VDiv> {
     public VDiv() {
         super();
-    }
-
-    public VDiv(String text) {
-        super();
-        add(new Text(text));
     }
 
     public VDiv(Component... components) {

--- a/src/main/java/org/vaadin/firitin/components/VH1.java
+++ b/src/main/java/org/vaadin/firitin/components/VH1.java
@@ -2,10 +2,10 @@ package org.vaadin.firitin.components;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.H1;
-import org.vaadin.firitin.fluency.ui.FluentHasComponents;
-import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
 
-public class VH1 extends H1 implements FluentHasComponents<VH1>, FluentHasStyle<VH1> {
+public class VH1 extends H1 implements FluentHtmlContainer<VH1>, FluentClickNotifierWithoutTypedSource<VH1> {
     public VH1() {
         super();
     }

--- a/src/main/java/org/vaadin/firitin/components/VH2.java
+++ b/src/main/java/org/vaadin/firitin/components/VH2.java
@@ -2,10 +2,10 @@ package org.vaadin.firitin.components;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.H2;
-import org.vaadin.firitin.fluency.ui.FluentHasComponents;
-import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
 
-public class VH2 extends H2 implements FluentHasComponents<VH2>, FluentHasStyle<VH2> {
+public class VH2 extends H2 implements FluentHtmlContainer<VH2>, FluentClickNotifierWithoutTypedSource<VH2> {
     public VH2() {
         super();
     }

--- a/src/main/java/org/vaadin/firitin/components/VH3.java
+++ b/src/main/java/org/vaadin/firitin/components/VH3.java
@@ -2,10 +2,10 @@ package org.vaadin.firitin.components;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.H3;
-import org.vaadin.firitin.fluency.ui.FluentHasComponents;
-import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
 
-public class VH3 extends H3 implements FluentHasComponents<VH3>, FluentHasStyle<VH3> {
+public class VH3 extends H3 implements FluentHtmlContainer<VH3>, FluentClickNotifierWithoutTypedSource<VH3> {
     public VH3() {
         super();
     }

--- a/src/main/java/org/vaadin/firitin/components/VH4.java
+++ b/src/main/java/org/vaadin/firitin/components/VH4.java
@@ -2,10 +2,10 @@ package org.vaadin.firitin.components;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.H4;
-import org.vaadin.firitin.fluency.ui.FluentHasComponents;
-import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
 
-public class VH4 extends H4 implements FluentHasComponents<VH4>, FluentHasStyle<VH4> {
+public class VH4 extends H4 implements FluentHtmlContainer<VH4>, FluentClickNotifierWithoutTypedSource<VH4> {
     public VH4() {
         super();
     }

--- a/src/main/java/org/vaadin/firitin/components/VH5.java
+++ b/src/main/java/org/vaadin/firitin/components/VH5.java
@@ -2,10 +2,10 @@ package org.vaadin.firitin.components;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.H5;
-import org.vaadin.firitin.fluency.ui.FluentHasComponents;
-import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
 
-public class VH5 extends H5 implements FluentHasComponents<VH5>, FluentHasStyle<VH5> {
+public class VH5 extends H5 implements FluentHtmlContainer<VH5>, FluentClickNotifierWithoutTypedSource<VH5> {
     public VH5() {
         super();
     }

--- a/src/main/java/org/vaadin/firitin/components/VH6.java
+++ b/src/main/java/org/vaadin/firitin/components/VH6.java
@@ -2,10 +2,10 @@ package org.vaadin.firitin.components;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.H6;
-import org.vaadin.firitin.fluency.ui.FluentHasComponents;
-import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
 
-public class VH6 extends H6 implements FluentHasComponents<VH6>, FluentHasStyle<VH6> {
+public class VH6 extends H6 implements FluentHtmlContainer<VH6>, FluentClickNotifierWithoutTypedSource<VH6> {
     public VH6() {
         super();
     }

--- a/src/main/java/org/vaadin/firitin/components/VSpan.java
+++ b/src/main/java/org/vaadin/firitin/components/VSpan.java
@@ -1,25 +1,17 @@
 package org.vaadin.firitin.components;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HtmlContainer;
-import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.Text;
-import org.vaadin.firitin.fluency.ui.FluentClickNotifier;
-import org.vaadin.firitin.fluency.ui.FluentComponent;
-import org.vaadin.firitin.fluency.ui.FluentHasComponents;
-import org.vaadin.firitin.fluency.ui.FluentHasStyle;
-import org.vaadin.firitin.fluency.ui.FluentThemableLayout;
+import com.vaadin.flow.component.html.Span;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
 
-@Tag(Tag.SPAN)
-public class VSpan extends HtmlContainer implements FluentComponent<VSpan>, FluentClickNotifier<VSpan, VSpan>,
-        FluentHasComponents<VSpan>, FluentHasStyle<VSpan>, FluentThemableLayout<VSpan> {
+public class VSpan extends Span implements FluentHtmlContainer<VSpan>, FluentClickNotifierWithoutTypedSource<VSpan> {
     public VSpan() {
         super();
     }
 
     public VSpan(String text) {
-        super();
-        add(new Text(text));
+        super(text);
     }
 
     public VSpan(Component... components) {

--- a/src/main/java/org/vaadin/firitin/components/dialog/VDialog.java
+++ b/src/main/java/org/vaadin/firitin/components/dialog/VDialog.java
@@ -1,0 +1,37 @@
+package org.vaadin.firitin.components.dialog;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.dialog.Dialog;
+import org.vaadin.firitin.fluency.ui.FluentComponent;
+import org.vaadin.firitin.fluency.ui.FluentHasComponents;
+import org.vaadin.firitin.fluency.ui.FluentHasSize;
+
+public class VDialog extends Dialog implements FluentComponent<VDialog>, FluentHasSize<VDialog>, FluentHasComponents<VDialog> {
+
+
+    public VDialog(Component... components) {
+        super(components);
+    }
+
+    public VDialog withCloseOnOutsideClick(boolean closeOnOutsideClick) {
+        setCloseOnOutsideClick(closeOnOutsideClick);
+        return this;
+    }
+
+    public VDialog withOpened(boolean opened) {
+        setOpened(opened);
+        return this;
+    }
+
+    public VDialog withOpenedChangeListener(ComponentEventListener<OpenedChangeEvent<Dialog>> listener) {
+        addOpenedChangeListener(listener);
+        return this;
+    }
+
+    public VDialog withDialogCloseActionListener(ComponentEventListener<DialogCloseActionEvent> listener) {
+        addDialogCloseActionListener(listener);
+        return this;
+    }
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VAnchor.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VAnchor.java
@@ -1,0 +1,35 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.server.AbstractStreamResource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VAnchor extends Anchor implements FluentHtmlContainer<VAnchor> {
+
+    public VAnchor() {
+        super();
+    }
+
+    public VAnchor(String href, String text) {
+        super(href, text);
+    }
+
+    public VAnchor(AbstractStreamResource href, String text) {
+        super(href, text);
+    }
+
+    public VAnchor withHref(String href) {
+        setHref(href);
+        return this;
+    }
+
+    public VAnchor withHref(AbstractStreamResource href) {
+        setHref(href);
+        return this;
+    }
+
+    public VAnchor withTarget(String target) {
+        setTarget(target);
+        return this;
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VArticle.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VArticle.java
@@ -1,0 +1,17 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Article;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VArticle extends Article implements FluentHtmlContainer<VArticle>, FluentClickNotifierWithoutTypedSource<VArticle> {
+
+    public VArticle() {
+        super();
+    }
+
+    public VArticle(Component... components) {
+        super(components);
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VAside.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VAside.java
@@ -1,0 +1,17 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Aside;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VAside extends Aside implements FluentHtmlContainer<VAside>, FluentClickNotifierWithoutTypedSource<VAside> {
+
+    public VAside() {
+        super();
+    }
+
+    public VAside(Component... components) {
+        super(components);
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VDescriptionList.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VDescriptionList.java
@@ -1,0 +1,9 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.html.DescriptionList;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VDescriptionList extends DescriptionList implements FluentHtmlContainer<VDescriptionList>, FluentClickNotifierWithoutTypedSource<VDescriptionList> {
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VEmphasis.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VEmphasis.java
@@ -1,0 +1,9 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.html.Emphasis;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VEmphasis extends Emphasis implements FluentHtmlContainer<VEmphasis>, FluentClickNotifierWithoutTypedSource<VEmphasis> {
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VFooter.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VFooter.java
@@ -1,0 +1,17 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Footer;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VFooter extends Footer implements FluentHtmlContainer<VFooter>, FluentClickNotifierWithoutTypedSource<VFooter> {
+
+    public VFooter() {
+        super();
+    }
+
+    public VFooter(Component... components) {
+        super(components);
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VHeader.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VHeader.java
@@ -1,0 +1,17 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Header;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VHeader extends Header implements FluentHtmlContainer<VHeader>, FluentClickNotifierWithoutTypedSource<VHeader> {
+
+    public VHeader() {
+        super();
+    }
+
+    public VHeader(Component... components) {
+        super(components);
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VHr.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VHr.java
@@ -1,0 +1,8 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.html.Hr;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VHr extends Hr implements FluentHtmlContainer<VHr> {
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VImage.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VImage.java
@@ -1,0 +1,36 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.server.AbstractStreamResource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VImage extends Image implements FluentHtmlContainer<VImage> {
+
+    public VImage() {
+        super();
+    }
+
+    public VImage(String src, String alt) {
+        super(src, alt);
+    }
+
+    public VImage(AbstractStreamResource src, String alt) {
+        super(src, alt);
+    }
+
+    public VImage withSrc(String src) {
+        setSrc(src);
+        return this;
+    }
+
+    public VImage withSrc(AbstractStreamResource src) {
+        setSrc(src);
+        return this;
+    }
+
+    public VImage withAlt(String alt) {
+        setAlt(alt);
+        return this;
+    }
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VLabel.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VLabel.java
@@ -1,0 +1,26 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Label;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VLabel extends Label implements FluentHtmlContainer<VLabel> {
+
+    public VLabel() {
+        super();
+    }
+
+    public VLabel(String text) {
+        super(text);
+    }
+
+    public VLabel withFor(Component forComponent) {
+        setFor(forComponent);
+        return this;
+    }
+
+    public VLabel withFor(String forId) {
+        setFor(forId);
+        return this;
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VListItem.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VListItem.java
@@ -1,0 +1,21 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.ListItem;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VListItem extends ListItem implements FluentHtmlContainer<VListItem>, FluentClickNotifierWithoutTypedSource<VListItem> {
+
+    public VListItem() {
+        super();
+    }
+
+    public VListItem(Component... components) {
+        super(components);
+    }
+
+    public VListItem(String text) {
+        super(text);
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VMain.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VMain.java
@@ -1,0 +1,18 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Main;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VMain extends Main implements FluentHtmlContainer<VMain>, FluentClickNotifierWithoutTypedSource<VMain> {
+
+    public VMain() {
+        super();
+    }
+
+    public VMain(Component... components) {
+        super(components);
+    }
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VNativeButton.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VNativeButton.java
@@ -1,0 +1,24 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.html.NativeButton;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifier;
+import org.vaadin.firitin.fluency.ui.FluentFocusable;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VNativeButton extends NativeButton implements FluentHtmlContainer<VNativeButton>, FluentClickNotifier<NativeButton, VNativeButton>, FluentFocusable<NativeButton, VNativeButton> {
+
+    public VNativeButton() {
+        super();
+    }
+
+    public VNativeButton(String text) {
+        super(text);
+    }
+
+    public VNativeButton(String text, ComponentEventListener<ClickEvent<NativeButton>> clickListener) {
+        super(text, clickListener);
+    }
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VNav.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VNav.java
@@ -1,0 +1,19 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Main;
+import com.vaadin.flow.component.html.Nav;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VNav extends Nav implements FluentHtmlContainer<VNav>, FluentClickNotifierWithoutTypedSource<VNav> {
+
+    public VNav() {
+        super();
+    }
+
+    public VNav(Component... components) {
+        super(components);
+    }
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VOrderedList.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VOrderedList.java
@@ -1,0 +1,27 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.html.ListItem;
+import com.vaadin.flow.component.html.OrderedList;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VOrderedList extends OrderedList implements FluentHtmlContainer<VOrderedList>, FluentClickNotifierWithoutTypedSource<VOrderedList> {
+
+    public VOrderedList() {
+        super();
+    }
+
+    public VOrderedList(OrderedList.NumberingType type) {
+        super(type);
+    }
+
+    public VOrderedList(ListItem... items) {
+        super(items);
+    }
+
+    public VOrderedList withType(OrderedList.NumberingType type) {
+        setType(type);
+        return this;
+    }
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VParagaph.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VParagaph.java
@@ -1,0 +1,22 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Paragraph;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VParagaph extends Paragraph implements FluentHtmlContainer<VParagaph>, FluentClickNotifierWithoutTypedSource<VParagaph> {
+
+    public VParagaph() {
+        super();
+    }
+
+    public VParagaph(Component... components) {
+        super(components);
+    }
+
+    public VParagaph(String text) {
+        super(text);
+    }
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VSection.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VSection.java
@@ -1,0 +1,19 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Nav;
+import com.vaadin.flow.component.html.Section;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VSection extends Section implements FluentHtmlContainer<VSection>, FluentClickNotifierWithoutTypedSource<VSection> {
+
+    public VSection() {
+        super();
+    }
+
+    public VSection(Component... components) {
+        super(components);
+    }
+
+}

--- a/src/main/java/org/vaadin/firitin/components/hmtl/VUnorderedList.java
+++ b/src/main/java/org/vaadin/firitin/components/hmtl/VUnorderedList.java
@@ -1,0 +1,18 @@
+package org.vaadin.firitin.components.hmtl;
+
+import com.vaadin.flow.component.html.ListItem;
+import com.vaadin.flow.component.html.UnorderedList;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifierWithoutTypedSource;
+import org.vaadin.firitin.fluency.ui.FluentHtmlContainer;
+
+public class VUnorderedList extends UnorderedList implements FluentHtmlContainer<VUnorderedList>, FluentClickNotifierWithoutTypedSource<VUnorderedList> {
+
+    public VUnorderedList() {
+        super();
+    }
+
+    public VUnorderedList(ListItem... items) {
+        super(items);
+    }
+
+}

--- a/src/main/java/org/vaadin/firitin/components/listbox/VListBox.java
+++ b/src/main/java/org/vaadin/firitin/components/listbox/VListBox.java
@@ -1,0 +1,26 @@
+package org.vaadin.firitin.components.listbox;
+
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.listbox.ListBox;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.function.SerializablePredicate;
+import org.vaadin.firitin.components.VComboBox;
+import org.vaadin.firitin.fluency.ui.*;
+
+public class VListBox<T> extends ListBox<T> implements FluentComponent<VListBox<T>>, FluentHasStyle<VListBox<T>>, FluentHasDataProvider<VListBox<T>, T>,
+        FluentHasSize<VComboBox<T>>, FluentHasItems<VListBox<T>, T>, FluentFocusable<ListBox<T>, VListBox<T>>, FluentHasValueAndElement<VListBox<T>, AbstractField.ComponentValueChangeEvent<ListBox<T>, T>, T> {
+
+
+    public VListBox withRenderer(
+            ComponentRenderer<? extends Component, T> itemRenderer) {
+        setRenderer(itemRenderer);
+        return this;
+    }
+
+    public VListBox withItemEnabledProvider(
+            SerializablePredicate<T> itemEnabledProvider) {
+        setItemEnabledProvider(itemEnabledProvider);
+        return this;
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/notification/VNotification.java
+++ b/src/main/java/org/vaadin/firitin/components/notification/VNotification.java
@@ -1,0 +1,51 @@
+package org.vaadin.firitin.components.notification;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.notification.Notification;
+import org.vaadin.firitin.fluency.ui.FluentComponent;
+import org.vaadin.firitin.fluency.ui.FluentHasComponents;
+
+public class VNotification extends Notification implements FluentComponent<VNotification>, FluentHasComponents<VNotification> {
+
+    public VNotification(String text) {
+        super(text);
+    }
+
+    public VNotification(String text, int duration) {
+        super(text, duration);
+    }
+
+    public VNotification(String text, int duration, Position position) {
+        super(text, duration, position);
+    }
+
+    public VNotification(Component... components) {
+        super(components);
+    }
+
+    public VNotification withText(String text) {
+        setText(text);
+        return this;
+    }
+
+    public VNotification withPosition(Position position) {
+        setPosition(position);
+        return this;
+    }
+
+    public VNotification withOpen() {
+        open();
+        return this;
+    }
+
+    public VNotification withDuration(int duration) {
+        setDuration(duration);
+        return this;
+    }
+
+    public VNotification withOpenedChangeListener(ComponentEventListener<OpenedChangeEvent<Notification>> listener) {
+        addOpenedChangeListener(listener);
+        return this;
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/orderedlayout/VFlexLayout.java
+++ b/src/main/java/org/vaadin/firitin/components/orderedlayout/VFlexLayout.java
@@ -1,0 +1,16 @@
+package org.vaadin.firitin.components.orderedlayout;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.orderedlayout.FlexLayout;
+import org.vaadin.firitin.fluency.ui.FluentComponent;
+
+public class VFlexLayout extends FlexLayout implements FluentComponent<VFlexLayout> {
+
+    public VFlexLayout() {
+        super();
+    }
+
+    public VFlexLayout(Component... children) {
+        super(children);
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/progressbar/VProgressBar.java
+++ b/src/main/java/org/vaadin/firitin/components/progressbar/VProgressBar.java
@@ -1,0 +1,37 @@
+package org.vaadin.firitin.components.progressbar;
+
+import com.vaadin.flow.component.progressbar.ProgressBar;
+import org.vaadin.firitin.fluency.ui.FluentComponent;
+import org.vaadin.firitin.fluency.ui.FluentHasSize;
+import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+
+public class VProgressBar extends ProgressBar implements FluentComponent<VProgressBar>, FluentHasSize<VProgressBar>, FluentHasStyle<VProgressBar> {
+
+    public VProgressBar() {
+        super();
+    }
+
+    public VProgressBar(double min, double max) {
+        super(min, max);
+    }
+
+    public VProgressBar(double min, double max, double value) {
+        super(min, max, value);
+    }
+
+    public VProgressBar withValue(double value) {
+        setValue(value);
+        return this;
+    }
+
+    public VProgressBar withMax(double max) {
+        setMax(max);
+        return this;
+    }
+
+    public VProgressBar withMin(double min) {
+        setMin(min);
+        return this;
+    }
+    
+}

--- a/src/main/java/org/vaadin/firitin/components/splitlayout/VSplitLayout.java
+++ b/src/main/java/org/vaadin/firitin/components/splitlayout/VSplitLayout.java
@@ -1,0 +1,47 @@
+package org.vaadin.firitin.components.splitlayout;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
+import org.vaadin.firitin.fluency.ui.FluentClickNotifier;
+import org.vaadin.firitin.fluency.ui.FluentComponent;
+import org.vaadin.firitin.fluency.ui.FluentHasSize;
+import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+
+public class VSplitLayout extends SplitLayout implements FluentComponent<VSplitLayout>, FluentHasStyle<VSplitLayout>, FluentHasSize<VSplitLayout>, FluentClickNotifier<SplitLayout, VSplitLayout> {
+
+    public VSplitLayout() {
+        super();
+    }
+
+    public VSplitLayout(Component primaryComponent,
+                        Component secondaryComponent) {
+        super(primaryComponent, secondaryComponent);
+    }
+
+    public VSplitLayout withOrientation(Orientation orientation) {
+        setOrientation(orientation);
+        return this;
+    }
+
+    public VSplitLayout withToPrimary(Component... components) {
+        addToPrimary(components);
+        return this;
+    }
+
+
+    public VSplitLayout withToSecondary(Component... components) {
+        addToSecondary(components);
+        return this;
+    }
+
+    public VSplitLayout withSplitterPosition(double position) {
+        setSplitterPosition(position);
+        return this;
+    }
+
+    public VSplitLayout withSplitterDragendListener(ComponentEventListener<SplitterDragendEvent<SplitLayout>> listener) {
+        addSplitterDragendListener(listener);
+        return this;
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/tabs/VTab.java
+++ b/src/main/java/org/vaadin/firitin/components/tabs/VTab.java
@@ -1,0 +1,32 @@
+package org.vaadin.firitin.components.tabs;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.tabs.Tab;
+import org.vaadin.firitin.fluency.ui.FluentComponent;
+import org.vaadin.firitin.fluency.ui.FluentHasComponents;
+import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+
+public class VTab extends Tab implements FluentComponent<VTab>, FluentHasStyle<VTab>, FluentHasComponents<VTab> {
+
+    public VTab() {
+        super();
+    }
+
+    public VTab(String label) {
+        super(label);
+    }
+
+    public VTab(Component... components) {
+        super(components);
+    }
+
+    public VTab withLabel(String label) {
+        setLabel(label);
+        return this;
+    }
+
+    public VTab withFlexGrow(double flexGrow) {
+        setFlexGrow(flexGrow);
+        return this;
+    }
+}

--- a/src/main/java/org/vaadin/firitin/components/tabs/VTabs.java
+++ b/src/main/java/org/vaadin/firitin/components/tabs/VTabs.java
@@ -1,0 +1,38 @@
+package org.vaadin.firitin.components.tabs;
+
+import com.vaadin.flow.component.tabs.Tab;
+import com.vaadin.flow.component.tabs.Tabs;
+import org.vaadin.firitin.fluency.ui.FluentComponent;
+import org.vaadin.firitin.fluency.ui.FluentHasComponents;
+import org.vaadin.firitin.fluency.ui.FluentHasStyle;
+
+public class VTabs extends Tabs implements FluentComponent<VTab>, FluentHasStyle<VTab>, FluentHasComponents<VTab> {
+
+    public VTabs() {
+        super();
+    }
+
+    public VTabs(Tab... tabs) {
+        super(tabs);
+    }
+
+    public VTabs withTab(Tab tab) {
+        add(tab);
+        return this;
+    }
+
+    public VTabs withSelectedTab(Tab selectedTab) {
+        setSelectedTab(selectedTab);
+        return this;
+    }
+
+    public VTabs withOrientation(Orientation orientation) {
+        setOrientation(orientation);
+        return this;
+    }
+
+    public VTabs withFlexGrowForEnclosedTabs(double flexGrow) {
+        setFlexGrowForEnclosedTabs(flexGrow);
+        return this;
+    }
+}

--- a/src/main/java/org/vaadin/firitin/fluency/ui/FluentClickNotifierWithoutTypedSource.java
+++ b/src/main/java/org/vaadin/firitin/fluency/ui/FluentClickNotifierWithoutTypedSource.java
@@ -1,0 +1,17 @@
+package org.vaadin.firitin.fluency.ui;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.ComponentEventListener;
+
+public interface FluentClickNotifierWithoutTypedSource<S extends FluentClickNotifierWithoutTypedSource<S>>
+        extends ClickNotifier {
+
+    @SuppressWarnings("unchecked")
+    default S withClickListener(ComponentEventListener<ClickEvent<?>> listener) {
+        // XXX This adds the listener in a fluent manner, but the Registration can't be
+        // used to unregister the listener
+        addClickListener(listener);
+        return (S) this;
+    }
+}

--- a/src/main/java/org/vaadin/firitin/fluency/ui/FluentHtmlContainer.java
+++ b/src/main/java/org/vaadin/firitin/fluency/ui/FluentHtmlContainer.java
@@ -1,0 +1,6 @@
+package org.vaadin.firitin.fluency.ui;
+
+public interface FluentHtmlContainer<S extends FluentHasComponents<S>& FluentHasText<S> & FluentHasStyle<S> & FluentHasSize<S> & FluentComponent<S>>
+        extends FluentHasComponents<S>, FluentHasText<S>, FluentHasStyle<S>, FluentHasSize<S>, FluentComponent<S>  {
+
+}


### PR DESCRIPTION
i've added missing components and separated each component package to have better overview.

In general I would welcome to move each fluent component-module in a separate package.
My suggestion would be to move existing html-components to org.vaadin.firitin.components.hmtl
When you like my approache I could create an extra pull-request (but this would like to breaking changes for other who already use viritin-flow)