### PR TITLE
Added getter/setter for Markdown

### DIFF
--- a/src/main/java/org/vaadin/firitin/components/messagelist/MarkdownMessage.java
+++ b/src/main/java/org/vaadin/firitin/components/messagelist/MarkdownMessage.java
@@ -40,6 +40,15 @@ public class MarkdownMessage extends Component {
     private static HtmlRenderer renderer;
     private static Parser parser;
     private UI ui;
+
+    public String getMarkdown() {
+        return markdown;
+    }
+
+    public void setMarkdown(String markdown) {
+        this.appendMarkdown(markdown);
+    }
+
     private String markdown;
     private String previousHtml;
 


### PR DESCRIPTION
Would be useful to get the Markdown stored using getMarkdown(). And that raised a question why there is not symmetrical setMarkdown.