### PR TITLE
Improve handling of class level validation violations

### DIFF
--- a/src/main/java/org/vaadin/firitin/form/FormBinder.java
+++ b/src/main/java/org/vaadin/firitin/form/FormBinder.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.data.binder.ValueContext;
 import com.vaadin.flow.data.converter.Converter;
 import com.vaadin.flow.data.value.HasValueChangeMode;
 import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.theme.lumo.LumoUtility;
 import jakarta.validation.ConstraintViolation;
@@ -74,6 +75,8 @@ public class FormBinder<T> implements HasValue<FormBinderValueChangeEvent<T>, T>
     private boolean ignoreServerOriginatedChanges = true;
 
     List<Registration> registrations = new ArrayList<>();
+
+    private SerializableFunction<String,Component> classLevelValidationViolationComponentProvider = new ParagraphWithErrorStyleClassLevelValidationViolationComponentProvider();
 
     /**
      * Constructs a new binder.
@@ -474,6 +477,10 @@ public class FormBinder<T> implements HasValue<FormBinderValueChangeEvent<T>, T>
         }
     }
 
+    public void setClassLevelValidationViolationComponentProvider(SerializableFunction<String, Component> classLevelValidationViolationComponentProvider) {
+        this.classLevelValidationViolationComponentProvider = Objects.requireNonNull(classLevelValidationViolationComponentProvider);
+    }
+
     /**
      * An alternative API to report constraint violations without BeanValidation
      * on the classpath.
@@ -508,10 +515,7 @@ public class FormBinder<T> implements HasValue<FormBinderValueChangeEvent<T>, T>
     }
 
     private Component createClassLevelValidationComponent(String message) {
-        Paragraph paragraph = new Paragraph();
-        paragraph.addClassNames(LumoUtility.TextColor.ERROR);
-        paragraph.setText(message);
-        return paragraph;
+        return classLevelValidationViolationComponentProvider.apply(message);
     }
 
     private void addClassLevelValidationViolation(Component validationViolationComponent) {
@@ -600,6 +604,16 @@ public class FormBinder<T> implements HasValue<FormBinderValueChangeEvent<T>, T>
 
     public HasValue getEditor(String property) {
         return nameToEditorField.get(property);
+    }
+
+    public static class ParagraphWithErrorStyleClassLevelValidationViolationComponentProvider implements SerializableFunction<String,Component> {
+        @Override
+        public Component apply(String message) {
+            Paragraph paragraph = new Paragraph();
+            paragraph.addClassNames(LumoUtility.TextColor.ERROR);
+            paragraph.setText(message);
+            return paragraph;
+        }
     }
 
 }

--- a/src/main/java/org/vaadin/firitin/form/FormBinder.java
+++ b/src/main/java/org/vaadin/firitin/form/FormBinder.java
@@ -464,19 +464,13 @@ public class FormBinder<T> implements HasValue<FormBinderValueChangeEvent<T>, T>
     }
 
     protected void handleClassLevelValidations(Set<ConstraintViolation<T>> violations) {
-        HasComponents hc = getClassLevelViolationDisplay();
         for (ConstraintViolation cv : violations) {
-            Paragraph paragraph = new Paragraph();
-            paragraph.addClassNames(LumoUtility.TextColor.ERROR);
             String propertyPath = cv.getPropertyPath().toString();
-            if (propertyPath.isEmpty()) {
-                paragraph.setText(cv.getMessage());
-            } else {
-                paragraph.setText(propertyPath + " " + cv.getMessage());
-            }
-
-            errorMsgs.add(paragraph);
-            hc.add(paragraph);
+            addClassLevelValidationViolation(
+                    createClassLevelValidationComponent(
+                            propertyPath.isEmpty() ? cv.getMessage() : propertyPath + " " + cv.getMessage()
+                    )
+            );
         }
     }
 
@@ -508,14 +502,22 @@ public class FormBinder<T> implements HasValue<FormBinderValueChangeEvent<T>, T>
     }
 
     private void handleClassLevelValidations(HashMap<String, String> nonReported) {
-        HasComponents hc = getClassLevelViolationDisplay();
-        nonReported.forEach((property, cv) -> {
-            Paragraph paragraph = new Paragraph();
-            paragraph.addClassNames(LumoUtility.TextColor.ERROR);
-            paragraph.setText(cv);
-            errorMsgs.add(paragraph);
-            hc.add(paragraph);
+        nonReported.forEach((_property, cv) -> {
+            addClassLevelValidationViolation(createClassLevelValidationComponent(cv));
         });
+    }
+
+    private Component createClassLevelValidationComponent(String message) {
+        Paragraph paragraph = new Paragraph();
+        paragraph.addClassNames(LumoUtility.TextColor.ERROR);
+        paragraph.setText(message);
+        return paragraph;
+    }
+
+    private void addClassLevelValidationViolation(Component validationViolationComponent) {
+        HasComponents hc = getClassLevelViolationDisplay();
+        errorMsgs.add(validationViolationComponent);
+        hc.add(validationViolationComponent);
     }
 
     /**


### PR DESCRIPTION
- Unify handling of the validation violations
- Don't try to find the location for adding them, if there are none to add
- Allow creating your own component for a the class level errors (with the default being the existing paragraph with an error style